### PR TITLE
Linked libtinfo in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INCLUDES=
 
 LFLAGS=
 
-LIBS=-lncurses
+LIBS=-lncurses -ltinfo
 
 SRCS=tetris.c
 


### PR DESCRIPTION
This fixes compilation on ArchLinux (and possibly some other platforms).